### PR TITLE
Remove debug print call

### DIFF
--- a/lua/notation/actions.lua
+++ b/lua/notation/actions.lua
@@ -10,7 +10,6 @@ local M = {}
 
 function M.add_tag(new_tag)
     local frontmatter = fm.get_frontmatter()
-    print("Got frontmatter: " .. vim.inspect(frontmatter))
     table.insert(frontmatter.data.tags, new_tag)
     fm.write_frontmatter(frontmatter)
 end


### PR DESCRIPTION
This PR removes a debug print call that was erroneously left in the function that adds a tag to the frontmatter.